### PR TITLE
Permissions readme section and python env

### DIFF
--- a/appengine/app.yaml
+++ b/appengine/app.yaml
@@ -1,6 +1,10 @@
-runtime: python27
+runtime: python
 api_version: 1
+env: flex
 threadsafe: true
+
+runtime_config:
+  python_version: 2
 
 handlers:
 - url: /assets

--- a/readme.md
+++ b/readme.md
@@ -53,7 +53,7 @@ GitHub.
 1. Go to https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts and create a Service Account in your project.
 2. Download the json file.
 3. Upload replacing the file in the `credentials` directory.
-
+4. Make sure the Service Account is allowed to access Google Search Console resources (https://search.google.com/u/1/search-console/users?resource_id={your_website}), use 'Add User' button and email address provided by Google under Service Accounts section
 
 ### 4. Deploy to App Engine
 


### PR DESCRIPTION
I experienced issues with this config of python ENV.
The most of the time were syntax errors thrown from httplib2 constructor being thrown.
This way it works on my setup.

Additional note to remember adding service user to search console read eligible was added too.

 